### PR TITLE
rely on the ElixirLS extension to provide the Elixir filetype for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
       }
     ]
   },
+  "extensionDependencies": [
+    "jakebecker.elixir-ls"
+  ],
   "main": "./dist/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run package",


### PR DESCRIPTION
fixes #62 